### PR TITLE
update-k8s-target-port

### DIFF
--- a/app/Dockerfile.frontend
+++ b/app/Dockerfile.frontend
@@ -46,12 +46,12 @@ RUN addgroup -g 1001 -S appgroup && \
     touch /var/run/nginx.pid && \
     chown -R appuser:appgroup /var/run/nginx.pid
 
-# Expose port 80
-EXPOSE 80
+# Expose port 8080 (non-root user cannot bind to port 80)
+EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:80/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
 # Run as non-root user
 USER appuser

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;

--- a/k8s/dev/deployment.yml
+++ b/k8s/dev/deployment.yml
@@ -23,7 +23,7 @@ spec:
         environment: dev
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "80"
+        prometheus.io/port: "8080"
         prometheus.io/path: "/health"
     spec:
       containers:
@@ -31,7 +31,7 @@ spec:
           image: __ACR_LOGIN_SERVER__/netflix-app:__IMAGE_TAG__
           imagePullPolicy: Always
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               protocol: TCP
           envFrom:
             - configMapRef:
@@ -46,7 +46,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 80
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 5
@@ -54,7 +54,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /ready
-              port: 80
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
@@ -92,20 +92,24 @@ spec:
                 name: netflix-app-secrets
           resources:
             requests:
-              cpu: "100m"
-              memory: "256Mi"
+              cpu: "200m"
+              memory: "1Gi"
             limits:
-              cpu: "500m"
-              memory: "512Mi"
+              cpu: "1000m"
+              memory: "2Gi"
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 15
+            initialDelaySeconds: 120
             periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 10
+            initialDelaySeconds: 90
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5

--- a/k8s/dev/service.yml
+++ b/k8s/dev/service.yml
@@ -13,7 +13,7 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
       name: http
 ---
 apiVersion: v1

--- a/k8s/prod/deployment.yml
+++ b/k8s/prod/deployment.yml
@@ -23,7 +23,7 @@ spec:
         environment: prod
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "80"
+        prometheus.io/port: "8080"
         prometheus.io/path: "/health"
     spec:
       containers:
@@ -31,7 +31,7 @@ spec:
           image: __ACR_LOGIN_SERVER__/netflix-app:__IMAGE_TAG__
           imagePullPolicy: Always
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               protocol: TCP
           envFrom:
             - configMapRef:
@@ -46,7 +46,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 80
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 5
@@ -54,7 +54,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /ready
-              port: 80
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
@@ -110,19 +110,23 @@ spec:
           resources:
             requests:
               cpu: "200m"
-              memory: "512Mi"
+              memory: "1Gi"
             limits:
               cpu: "1000m"
-              memory: "1Gi"
+              memory: "2Gi"
           livenessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 15
+            initialDelaySeconds: 120
             periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 10
+            initialDelaySeconds: 90
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5

--- a/k8s/prod/service.yml
+++ b/k8s/prod/service.yml
@@ -13,7 +13,7 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
       name: http
 ---
 apiVersion: v1


### PR DESCRIPTION
- Increased health check delays: liveness 120s, readiness 90s 
- Changed Nginx to listen on port 8080
- Changed target port to 8080 in some k8s manifest files